### PR TITLE
Display intersection value in page footer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import Intersection from "./states/intersection";
 import TrafficLight from "./components/traffic-light";
 import Pedestrian from "./components/pedestrian";
 
-import { Store, create } from "microstates";
+import { Store, create, valueOf } from "microstates";
 
 import "./style.css";
 
@@ -30,7 +30,7 @@ class App extends React.Component {
           <TrafficLight light={intersection.light} />
           <Pedestrian pedestrian={intersection.pedestrian} />
         </main>
-        <footer>Time left: {intersection.light.timer.state}</footer>{" "}
+        <footer>Value: {JSON.stringify(valueOf(intersection), undefined, 2)}</footer>{" "}
       </>
     );
   }

--- a/src/style.css
+++ b/src/style.css
@@ -29,7 +29,6 @@ footer {
   display: flex;
   flex-grow: initial;
   font-size: 24px;
-  font-weight: bold;
   font-family: sans-serif;
   padding: 40px 60px 40px 300px;
 }


### PR DESCRIPTION
I'm replacing the `Time left: X` section with a real time value of the intersection microstate.

##Screenshots
*BEFORE*
<img width="1163" alt="screen shot 2018-12-11 at 2 11 52 pm" src="https://user-images.githubusercontent.com/15052791/49827363-0b7ab600-fd81-11e8-90a0-639244440a41.png">

*AFTER*
<img width="1353" alt="screen shot 2018-12-11 at 2 10 18 pm" src="https://user-images.githubusercontent.com/15052791/49827257-cfdfec00-fd80-11e8-8b66-2a2d91391a8c.png">

