### PR TITLE
Remove @bigtest/converence in favour of Interactor.convergence

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "main": "src/index.js",
   "license": "MIT",
   "dependencies": {
-    "@bigtest/convergence": "1.1.1",
     "@bigtest/interactor": "0.9.1",
     "@bigtest/react": "0.1.2",
     "coveralls": "3.0.2",

--- a/src/components/app.test.js
+++ b/src/components/app.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { mount } from "@bigtest/react";
-import { when } from '@bigtest/convergence';
 
 import { IntersectionInteractor } from './intersection.test';
 import App from './app';
@@ -14,7 +13,7 @@ describe("<App />", () => {
     expect(intersection.light.isRed).toBe(true);
     expect(intersection.pedestrian.isStanding).toBe(true);
 
-    await when(() => intersection.light.isGreen);
+    await intersection.when(() => intersection.light.isGreen);
 
     expect(intersection.light.isGreen).toBe(true);
     expect(intersection.pedestrian.isWalking).toBe(true);

--- a/src/components/intersection.test.js
+++ b/src/components/intersection.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { mount } from "@bigtest/react";
 import Interactor from "@bigtest/interactor";
-import { when } from '@bigtest/convergence';
 import { create, Store } from "microstates";
 
 import Intersection from "./intersection";
@@ -45,7 +44,7 @@ describe("<Intersection />", () => {
     expect(intersection.light.isBlinking).toBe(true);
     expect(intersection.pedestrian.isWalking).toBe(true);
 
-    await when(() => intersection.light.isYellow);
+    await intersection.when(() => intersection.light.isYellow);
 
     expect(intersection.pedestrian.isStanding).toBe(false);
     expect(intersection.light.isBlinking).toBe(false);
@@ -62,7 +61,7 @@ describe("<Intersection />", () => {
     expect(intersection.light.isYellow).toBe(true);
     expect(intersection.pedestrian.isRunning).toBe(true);
 
-    await when(() => intersection.light.isRed);
+    await intersection.when(() => intersection.light.isRed);
 
     expect(intersection.light.isRed).toBe(true);
     expect(intersection.pedestrian.isRunning).toBe(false);
@@ -79,7 +78,7 @@ describe("<Intersection />", () => {
     expect(intersection.light.isRed).toBe(true);
     expect(intersection.pedestrian.isStanding).toBe(true);
 
-    await when(() => intersection.light.isGreen);
+    await intersection.when(() => intersection.light.isGreen);
 
     expect(intersection.light.isRed).toBe(false);
     expect(intersection.light.isGreen).toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,7 +858,7 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@bigtest/convergence@1.1.1", "@bigtest/convergence@^1.1.1":
+"@bigtest/convergence@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-1.1.1.tgz#b314d8b1edc392d3e8780f99499a9a03aa528d54"
   integrity sha512-zorukvQJ7JxD5Jqy3ChzhCJzlD45bZudBASbgJvY5ffw5Hu+/9Ia/+8KlU1/XRWm32O2P5SBB2soHoFtGi1eGQ==


### PR DESCRIPTION
Interactors have `.when` on them, so there is no need to import the `@bigtest/convergence` package. 