### PR TITLE
Add union types:

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@bigtest/react": "0.1.2",
     "coveralls": "3.0.2",
     "classnames": "2.2.6",
-    "microstates": "0.12.2",
+    "microstates": "0.12.3",
     "prop-types": "15.6.2",
     "react": "16.6.3",
     "react-dom": "16.6.3",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,7 +7,7 @@ import IntersectionState from '../states/intersection';
 export default class App extends React.Component {
   static defaultProps = {
     initial: create(IntersectionState, {
-      light: { color: "red", timer: 1 }
+      light: { color: { type: "Red" }, timer: 1 }
     })
   }
 

--- a/src/components/intersection.test.js
+++ b/src/components/intersection.test.js
@@ -35,7 +35,7 @@ describe("<Intersection />", () => {
 
   it("goes from green to yellow", async () => {
     let state = create(IntersectionState, {
-      light: { color: 'green', timer: 1 }
+      light: { color: {type: 'Green' }, timer: 1 }
     });
 
     await mountState(state, $ => <Intersection intersection={$} />);
@@ -53,11 +53,11 @@ describe("<Intersection />", () => {
 
   it('goes from yellow to red', async () => {
     let state = create(IntersectionState, {
-      light: { color: 'yellow', timer: 1 }
+      light: { color: { type: 'Yellow' }, timer: 1 }
     });
 
     await mountState(state, $ => <Intersection intersection={$} />);
-    
+
     expect(intersection.light.isYellow).toBe(true);
     expect(intersection.pedestrian.isRunning).toBe(true);
 
@@ -70,7 +70,7 @@ describe("<Intersection />", () => {
 
   it('goes from red to green', async () => {
     let state = create(IntersectionState, {
-      light: { color: 'red', timer: 1 }
+      light: { color: { type: 'Red' }, timer: 1 }
     });
 
     await mountState(state, $ => <Intersection intersection={$} />);

--- a/src/components/pedestrian.test.js
+++ b/src/components/pedestrian.test.js
@@ -20,7 +20,7 @@ describe("<Pedestrian />", () => {
   let pedestrian = new PedestrianInteractor();
 
   it("is standing", async () => {
-    let person = create(Person, { activity: "standing" });
+    let person = create(Person).activity.stop();
 
     await mount(() => (
       <Pedestrian pedestrian={person} />
@@ -31,7 +31,7 @@ describe("<Pedestrian />", () => {
   });
 
   it("is running", async() => {
-    let person = create(Person, { activity: "running" });
+    let person = create(Person).activity.run();
 
     await mount(() => (
       <Pedestrian pedestrian={person} />
@@ -42,7 +42,7 @@ describe("<Pedestrian />", () => {
   });
 
   it("is walking", async() => {
-    let person = create(Person, { activity: "walking" });
+    let person = create(Person).activity.walk();
 
     await mount(() => (
       <Pedestrian pedestrian={person} />

--- a/src/components/traffic-light.test.js
+++ b/src/components/traffic-light.test.js
@@ -19,29 +19,29 @@ export const TrafficLightInteractor = Interactor.extend(
 describe('<TrafficLight />', () => {
   let interactor = new TrafficLightInteractor();
 
-  it('is green', async () => {  
-    let light = create(State, { color: 'green' });
+  it('is green', async () => {
+    let light = create(State, { color: { type: 'Green' } });
     await mount(() => <TrafficLight light={light} />);
 
     expect(interactor.isGreen).toBe(true);
   });
 
   it('is red', async () => {
-    let light = create(State, { color: 'red' });
+    let light = create(State, { color: { type: 'Red' } });
     await mount(() => <TrafficLight light={light} />);
 
     expect(interactor.isRed).toBe(true);
   });
 
   it('is yellow', async () => {
-    let light = create(State, { color: 'yellow' });
+    let light = create(State, { color: {type: 'Yellow' }});
     await mount(() => <TrafficLight light={light} />);
 
     expect(interactor.isYellow).toBe(true);
   });
 
-  it('is green', async () => {  
-    let light = create(State, { color: 'green', timer: 6 });
+  it('is green', async () => {
+    let light = create(State, { color: { type: 'Green' }, timer: 6 });
     await mount(() => <TrafficLight light={light} />);
 
     expect(interactor.isBlinking).toBe(true);

--- a/src/states/intersection.js
+++ b/src/states/intersection.js
@@ -19,11 +19,11 @@ export default class Intersection {
     if (color.isGreen) {
       return activity.walk();
     }
-    
+
     if (color.isYellow) {
       return activity.run();
     }
-    
+
     return activity.stop();
   }
 

--- a/src/states/intersection.test.js
+++ b/src/states/intersection.test.js
@@ -32,7 +32,7 @@ describe("Intersection State", () => {
     beforeEach(() => {
       intersection = create(Intersection, {
         light: { color: { type: "Yellow" }, timer: 3 },
-        pedestrian: { activity: "walking" }
+        pedestrian: { activity: { type: "Walking" } }
       }).tick();
     });
     it('has yellow light', () => {
@@ -50,7 +50,7 @@ describe("Intersection State", () => {
     beforeEach(() => {
       intersection = create(Intersection, {
         light: { color: { type: 'Red' }, timer: 3 },
-        pedestrian: { activity: 'running' }
+        pedestrian: { activity: { type: 'Running' } }
       }).tick();
     });
     it('has red light', () => {

--- a/src/states/intersection.test.js
+++ b/src/states/intersection.test.js
@@ -6,7 +6,7 @@ describe("Intersection State", () => {
     let intersection;
     beforeEach(() => {
       intersection = create(Intersection, {
-        light: { color: "green", timer: 3 }
+        light: { color: { type: "Green" }, timer: 3 }
       });
     });
     it("has pedestrian walking", () => {
@@ -31,7 +31,7 @@ describe("Intersection State", () => {
     let intersection;
     beforeEach(() => {
       intersection = create(Intersection, {
-        light: { color: "yellow", timer: 3 },
+        light: { color: { type: "Yellow" }, timer: 3 },
         pedestrian: { activity: "walking" }
       }).tick();
     });
@@ -49,7 +49,7 @@ describe("Intersection State", () => {
     let intersection;
     beforeEach(() => {
       intersection = create(Intersection, {
-        light: { color: 'red', timer: 3 },
+        light: { color: { type: 'Red' }, timer: 3 },
         pedestrian: { activity: 'running' }
       }).tick();
     });

--- a/src/states/person.js
+++ b/src/states/person.js
@@ -1,62 +1,23 @@
 import { create } from 'microstates';
+import Union from './union';
 
-class Activity {
-  initialize(value) {
-    switch(value) {
-      case 'running':
-        return create(Running, this);
-      case 'walking':
-        return create(Walking, this);
-      case 'standing':
-        return create(Standing, this);
-      default:
-        return this;
-    }
-  }
-
+const Activity = Union({
+  Walking: Activity => class extends Activity {},
+  Standing: Activity => class extends Activity {},
+  Running: Activity => class extends Activity {}
+}, class {
   stop() {
-    return this.set('standing');
+    return this.type.toStanding();
   }
-
   run() {
-    return this.set('running');
+    return this.type.toRunning();
   }
-
   walk() {
-    return this.set('walking');
+    return this.type.toWalking();
   }
-}
+});
 
-class Walking extends Activity {
-  get isWalking() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-}
-
-class Standing extends Activity {
-  get isStanding() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-}
-
-class Running extends Activity {
-  get isRunning() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-}
 
 export default class Person {
-  activity = Activity;
+  activity = Activity.Standing.create();
 }

--- a/src/states/person.test.js
+++ b/src/states/person.test.js
@@ -8,24 +8,20 @@ describe('Person state', () => {
 
       let person;
       beforeEach(() => {
-        person = create(Person, { activity: 'standing'});
+        person = create(Person, { activity: { type: 'Standing' } });
       });
-  
+
       it('initializes to standing without initial value', () => {
         expect(person.activity.isStanding).toBe(true);
       });
-  
+
       describe('walk transition', () => {
         beforeEach(() => {
           person = person.activity.walk();
         });
-  
+
         it('is walking', () => {
           expect(person.activity.isWalking).toBe(true);
-        });
-  
-        it('has value of walking', () => {
-          expect(valueOf(person.activity)).toBe('walking');
         });
       });
 
@@ -37,19 +33,15 @@ describe('Person state', () => {
         it('is running', () => {
           expect(person.activity.isRunning).toBe(true)
         });
-
-        it('has value of running', () => {
-          expect(valueOf(person.activity)).toBe('running');
-        });
       });
-  
+
     });
-  
+
     describe('Walking state', () => {
 
       let person;
       beforeEach(() => {
-        person = create(Person, { activity: 'walking' });
+        person = create(Person, { activity: { type: 'Walking'  } });
       });
 
       it('initializes to walking when activitiy value is walking', () => {
@@ -64,10 +56,6 @@ describe('Person state', () => {
         it('is standing', () => {
           expect(person.activity.isStanding).toBe(true);
         });
-
-        it('has value of standing', () => {
-          expect(valueOf(person.activity)).toBe('standing');
-        });
       });
 
       describe('run transition', () => {
@@ -78,17 +66,13 @@ describe('Person state', () => {
         it('is running', () => {
           expect(person.activity.isRunning).toBe(true)
         });
-
-        it('has value of running', () => {
-          expect(valueOf(person.activity)).toBe('running');
-        });
       });
     });
 
     describe('Running state', () => {
       let person;
       beforeEach(() => {
-        person = create(Person, { activity: 'running' });
+        person = create(Person, { activity: { type: 'Running' } });
       });
 
       it('initializes into running state when value is running', () => {
@@ -99,13 +83,9 @@ describe('Person state', () => {
         beforeEach(() => {
           person = person.activity.walk();
         });
-  
+
         it('is walking', () => {
           expect(person.activity.isWalking).toBe(true);
-        });
-  
-        it('has value of walking', () => {
-          expect(valueOf(person.activity)).toBe('walking');
         });
       });
 
@@ -117,15 +97,7 @@ describe('Person state', () => {
         it('is standing', () => {
           expect(person.activity.isStanding).toBe(true);
         });
-
-        it('has value of standing', () => {
-          expect(valueOf(person.activity)).toBe('standing');
-        });
       });
-
     });
   });
-
-
-
 });

--- a/src/states/traffic-light.js
+++ b/src/states/traffic-light.js
@@ -1,71 +1,35 @@
 import { create } from "microstates";
 
+import Union from './union';
+
 const LONG_TIME = 15;
 const SHORT_TIME = 5;
 
-export class Color {
-  initialize(value) {
-    switch (value) {
-      case 'green': 
-        return create(Green, this);
-      case 'yellow':
-        return create(Yellow, this);
-      case 'red':
-        return create(Red, this);
-      default:
-        return this;
+
+export const Color = Union({
+  Red: Color => class extends Color {
+    change() {
+      return Color.Green.create();
+    }
+  },
+  Yellow: Color => class extends Color {
+    change() {
+      return Color.Red.create();
+    }
+  },
+  Green: Color => class extends Color {
+    change() {
+      return Color.Yellow.create();
     }
   }
-}
-
-class Red extends Color {
-  get isRed() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-
-  change() {
-    return this.set('green');
-  }
-}
-
-class Yellow extends Color {
-  get isYellow() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-
-  change() {
-    return this.set('red');
-  }
-}
-
-class Green extends Color {
-  get isGreen() {
-    return true;
-  }
-
-  initialize(value) {
-    return super.initialize(value);
-  }
-  
-  change() {
-    return this.set('yellow');
-  }
-}
+});
 
 export default class TrafficLight {
-  color = create(Color, 'red');
+  color = Color.Red.create();
   timer = create(Number, LONG_TIME);
 
   initialize(value = {}) {
-    if (value.color === 'yellow' && value.timer === undefined) {
+    if (this.color.isYellow && value.timer === undefined) {
       return this.timer.set(SHORT_TIME);
     }
     return this;
@@ -78,7 +42,7 @@ export default class TrafficLight {
   cycle() {
     let next = this.timer.decrement();
     if (next.timer.state <= 0) {
-      // when the time expired, change the color      
+      // when the time expired, change the color
       let changed = next.color.change();
       if (changed.color.isYellow) {
         // yellow only runs for 5 seconds

--- a/src/states/traffic-light.js
+++ b/src/states/traffic-light.js
@@ -9,17 +9,17 @@ const SHORT_TIME = 5;
 export const Color = Union({
   Red: Color => class extends Color {
     change() {
-      return Color.Green.create();
+      return this.type.toGreen();
     }
   },
   Yellow: Color => class extends Color {
     change() {
-      return Color.Red.create();
+      return this.type.toRed();
     }
   },
   Green: Color => class extends Color {
     change() {
-      return Color.Yellow.create();
+      return this.type.toYellow();
     }
   }
 });

--- a/src/states/traffic-light.test.js
+++ b/src/states/traffic-light.test.js
@@ -7,7 +7,7 @@ describe('Traffic Light State', () => {
   describe('cycle transition', () => {
     describe('from green', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'green', timer: 1 }).cycle();
+        light = create(TrafficLight, { color: { type: 'Green' }, timer: 1 }).cycle();
       });
       it('transitions to yellow', () => {
         expect(light.color.isYellow).toBe(true);
@@ -16,10 +16,10 @@ describe('Traffic Light State', () => {
         expect(light.timer.state).toBe(5);
       });
     });
-    
+
     describe('from red', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'red', timer: 1 }).cycle();
+        light = create(TrafficLight, { color: { type: 'Red' }, timer: 1 }).cycle();
       });
       it('transitions to green', () => {
         expect(light.color.isGreen).toBe(true);
@@ -30,7 +30,7 @@ describe('Traffic Light State', () => {
     });
     describe('from yellow', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'yellow', timer: 1 }).cycle();
+        light = create(TrafficLight, { color: {type: 'Yellow' }, timer: 1 }).cycle();
       });
       it('transitions to red', () => {
         expect(light.color.isRed).toBe(true);
@@ -58,13 +58,13 @@ describe('Traffic Light State', () => {
   describe('with color but without timer', () => {
     describe('when color is red', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'red' });
+        light = create(TrafficLight, { color: { type: 'Red' } });
       });
-  
+
       it('initializes into red', () => {
         expect(light.color.isRed).toBe(true);
       });
-  
+
       it('initializes timer to 15', () => {
         expect(light.timer.state).toBe(15);
       });
@@ -72,13 +72,13 @@ describe('Traffic Light State', () => {
 
     describe('when color is green', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'green' });
+        light = create(TrafficLight, { color: { type: 'Green' } });
       });
 
       it('initializes into green', () => {
         expect(light.color.isGreen).toBe(true);
       });
-  
+
       it('initializes timer to 15', () => {
         expect(light.timer.state).toBe(15);
       });
@@ -86,13 +86,13 @@ describe('Traffic Light State', () => {
 
     describe('when color is yellow', () => {
       beforeEach(() => {
-        light = create(TrafficLight, { color: 'yellow' });
+        light = create(TrafficLight, { color: { type: 'Yellow' } });
       });
 
       it('initializes into yellow', () => {
         expect(light.color.isYellow).toBe(true);
       });
-  
+
       it('initializes timer to 5', () => {
         expect(light.timer.state).toBe(5);
       });
@@ -103,15 +103,15 @@ describe('Traffic Light State', () => {
     let color;
     describe('Red state', () => {
       beforeEach(() => {
-        color = create(Color, 'red');
+        color = Color.Red.create();
       });
       it('initializes into red', () => {
         expect(color.isRed).toBe(true);
       });
       it('has red as value', () => {
-        expect(valueOf(color)).toBe('red');
+        expect(color.type).toEqual('Red');
       })
-  
+
       describe('change transition', () => {
         beforeEach(() => {
           color = color.change();
@@ -120,20 +120,20 @@ describe('Traffic Light State', () => {
           expect(color.isGreen).toBe(true);
         });
         it('has green as value', () => {
-          expect(valueOf(color)).toBe('green');
+          expect(color.type).toBe('Green');
         });
       });
     });
 
     describe('Green state', () => {
       beforeEach(() => {
-        color = create(Color, 'green');
+        color = Color.Green.create();
       });
       it('initializes to green', () => {
         expect(color.isGreen).toBe(true);
       });
       it('has green as value', () => {
-        expect(valueOf(color)).toBe('green');
+        expect(color.type).toBe('Green');
       });
       describe('change transition', () => {
         beforeEach(() => {
@@ -143,20 +143,20 @@ describe('Traffic Light State', () => {
           expect(color.isYellow).toBe(true);
         });
         it('has yellow as value', () => {
-          expect(valueOf(color)).toBe('yellow');
+          expect(color.type).toBe('Yellow');
         });
       });
     });
 
     describe('Yellow state', () => {
       beforeEach(() => {
-        color = create(Color, 'yellow');
+        color = Color.Yellow.create();
       });
       it('initializes to yellow', () => {
         expect(color.isYellow).toBe(true);
       });
       it('has yellow as value', () => {
-        expect(valueOf(color)).toBe('yellow');
+        expect(color.type).toBe('Yellow');
       });
       describe('change transition', () => {
         beforeEach(() => {
@@ -166,11 +166,9 @@ describe('Traffic Light State', () => {
           expect(color.isRed).toBe(true);
         });
         it('has red as value', () => {
-          expect(valueOf(color)).toBe('red');
+          expect(color.type).toBe('Red');
         });
       });
     });
   });
-
-
 });

--- a/src/states/traffic-light.test.js
+++ b/src/states/traffic-light.test.js
@@ -109,7 +109,7 @@ describe('Traffic Light State', () => {
         expect(color.isRed).toBe(true);
       });
       it('has red as value', () => {
-        expect(color.type).toEqual('Red');
+        expect(color.type.state).toEqual('Red');
       })
 
       describe('change transition', () => {
@@ -120,7 +120,7 @@ describe('Traffic Light State', () => {
           expect(color.isGreen).toBe(true);
         });
         it('has green as value', () => {
-          expect(color.type).toBe('Green');
+          expect(color.type.state).toBe('Green');
         });
       });
     });
@@ -133,7 +133,7 @@ describe('Traffic Light State', () => {
         expect(color.isGreen).toBe(true);
       });
       it('has green as value', () => {
-        expect(color.type).toBe('Green');
+        expect(color.type.state).toBe('Green');
       });
       describe('change transition', () => {
         beforeEach(() => {
@@ -143,7 +143,7 @@ describe('Traffic Light State', () => {
           expect(color.isYellow).toBe(true);
         });
         it('has yellow as value', () => {
-          expect(color.type).toBe('Yellow');
+          expect(color.type.state).toBe('Yellow');
         });
       });
     });
@@ -156,7 +156,7 @@ describe('Traffic Light State', () => {
         expect(color.isYellow).toBe(true);
       });
       it('has yellow as value', () => {
-        expect(color.type).toBe('Yellow');
+        expect(color.type.state).toBe('Yellow');
       });
       describe('change transition', () => {
         beforeEach(() => {
@@ -166,7 +166,7 @@ describe('Traffic Light State', () => {
           expect(color.isRed).toBe(true);
         });
         it('has red as value', () => {
-          expect(color.type).toBe('Red');
+          expect(color.type.state).toBe('Red');
         });
       });
     });

--- a/src/states/union.js
+++ b/src/states/union.js
@@ -1,12 +1,11 @@
-import { create, valueOf } from 'microstates';
+import { create, valueOf, Primitive } from 'microstates';
 
-export default function Union(members) {
+export default function Union(members, Base = Object) {
   let types = Object.keys(members);
 
-  let UnionType = class {
-    get type() {
-      return valueOf(this).type;
-    }
+  let UnionType = class extends Base {
+
+    type = TypeId(types);
 
     initialize(value) {
       let { type } = value == null ? {} : value;
@@ -57,6 +56,24 @@ export default function Union(members) {
   return UnionType;
 }
 
+
+function TypeId(types) {
+
+  class TypeId extends Primitive {}
+
+  types.forEach(type => {
+    Object.defineProperty(TypeId.prototype, `to${type}`, {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value() {
+        return this.set(type);
+      }
+    });
+  });
+
+  return TypeId;
+}
 
 function assert(condition, message) {
   if (!condition) {

--- a/src/states/union.js
+++ b/src/states/union.js
@@ -1,0 +1,65 @@
+import { create, valueOf } from 'microstates';
+
+export default function Union(members) {
+  let types = Object.keys(members);
+
+  let UnionType = class {
+    get type() {
+      return valueOf(this).type;
+    }
+
+    initialize(value) {
+      let { type } = value == null ? {} : value;
+      assert(type != null && types.includes(type),
+             `when re-structuring a Union type, the 'type' field must be one of [${types}], but it was '${type}'`);
+
+      return create(UnionType[type], value);
+    }
+  };
+
+  types.forEach(type => {
+    let Constructor = members[type](UnionType);
+
+    Object.defineProperty(UnionType.prototype, `is${type}`, {
+      enumerable: false,
+      value: false
+    })
+
+    Object.defineProperty(Constructor.prototype, `is${type}`, {
+      enumerable: false,
+      value: true
+    });
+
+    Object.defineProperty(Constructor.prototype, `initialize`, {
+      enumerable: false,
+      configurable: true,
+      writable: true,
+      value: function(...args) {
+        if (valueOf(this).type === type) {
+          return this;
+        } else {
+          return UnionType.prototype.initialize(...args);
+        }
+      }
+    });
+
+    Object.defineProperty(Constructor,  'name', {
+      enumerable: false,
+      configurable: true,
+      value: type
+    });
+    Constructor.create = (value) => {
+      return create(UnionType, { type, value });
+    };
+    UnionType[type] = Constructor;
+  });
+
+  return UnionType;
+}
+
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/src/states/union.test.js
+++ b/src/states/union.test.js
@@ -1,0 +1,88 @@
+import Union from './union';
+import { create, valueOf } from 'microstates';
+
+describe('Using a union type to construct a Maybe value', ()=> {
+  function Maybe(Type) {
+    return Union({
+      Just: Maybe => class extends Maybe {
+        value = Type;
+
+        disintegrate() {
+          return Maybe.Nothing.create();
+        }
+
+      },
+      Nothing: Maybe => class extends Maybe {}
+    });
+  }
+
+  let Type;
+  beforeEach(()=> {
+    Type = Maybe(Number);
+  });
+
+  it('cannot construct a type directly without passing it a valid serialized form', ()=> {
+    expect(()=> create(Type)).toThrow('[Just,Nothing]');
+  });
+
+  it('has a constructor for each member of the union', ()=> {
+    expect(Type).toBeDefined();
+    expect(Type).toBeInstanceOf(Function);
+    expect(Type.Just).toBeInstanceOf(Function);
+    expect(Type.Nothing).toBeInstanceOf(Function);
+  });
+
+  it('creates each member as a subclass of union type', ()=> {
+    let { Just, Nothing } = Type;
+    expect(Just.prototype).toBeInstanceOf(Type);
+    expect(Nothing.prototype).toBeInstanceOf(Type);
+  });
+
+  it('sets the name of the union members', ()=> {
+    let { Just, Nothing } = Type;
+    expect(Just.name).toEqual('Just');
+    expect(Nothing.name).toEqual('Nothing');
+  });
+
+
+  describe('constructing an instance of Just', ()=> {
+    let just;
+    beforeEach(()=> {
+      let { Just } = Type;
+      just = Just.create(5);
+    });
+    it('gives you a value that is an instance of Just, and also contains the attributes.', ()=> {
+      expect(just).toBeInstanceOf(Type.Just);
+      expect(just.isJust).toEqual(true);
+      expect(just.isNothing).toEqual(false)
+    });
+    it('it has as its value, an instance of Number', ()=> {
+      expect(just.value.state).toEqual(5);
+    });
+
+    describe('transitioning the value', ()=> {
+      let next;
+      beforeEach(()=> {
+        next = just.value.increment();
+      });
+      it('properly updates the whole structure', ()=> {
+        expect(next).toBeInstanceOf(Type.Just);
+        expect(next.value.state).toEqual(6);
+      });
+    });
+
+    describe('invoking a custom transition to another state', () => {
+      let next;
+
+      beforeEach(()=> {
+        next = just.disintegrate()
+      });
+
+      it('returns the nothing', ()=> {
+        let { Nothing } = Type;
+        expect(next).toBeInstanceOf(Nothing);
+      });
+    })
+  });
+
+});

--- a/src/states/union.test.js
+++ b/src/states/union.test.js
@@ -3,17 +3,17 @@ import { create, valueOf } from 'microstates';
 
 describe('Using a union type to construct a Maybe value', ()=> {
   function Maybe(Type) {
-    return Union({
+    let MaybeType = Union({
       Just: Maybe => class extends Maybe {
         value = Type;
-
-        disintegrate() {
-          return Maybe.Nothing.create();
-        }
-
       },
       Nothing: Maybe => class extends Maybe {}
+    }, class Maybe {
+      disintegrate() {
+        return MaybeType.Nothing.create()
+      }
     });
+    return MaybeType;
   }
 
   let Type;
@@ -59,6 +59,9 @@ describe('Using a union type to construct a Maybe value', ()=> {
     it('it has as its value, an instance of Number', ()=> {
       expect(just.value.state).toEqual(5);
     });
+    it('has the type string available on the type attribute', ()=> {
+      expect(just.type.state).toEqual('Just');
+    });
 
     describe('transitioning the value', ()=> {
       let next;
@@ -85,4 +88,32 @@ describe('Using a union type to construct a Maybe value', ()=> {
     })
   });
 
+  describe('transitioning from one type to the next', ()=> {
+    let maybe;
+    beforeEach(()=> {
+      let { Just } = Type;
+      maybe = Just.create(5).type.toNothing();
+    });
+
+    it('takes on the transitioned type', ()=> {
+      expect(maybe).toBeInstanceOf(Type.Nothing);
+    });
+  });
+
+  describe('transitioning from one type to the next and then back again', ()=> {
+    it('remains of the correct type.', ()=> {
+      expect(Type.Just.create(5).type.toNothing().type.toJust()).toBeInstanceOf(Type.Just);
+    });
+    it('retains its value', ()=> {
+      expect(Type.Just.create(5).type.toNothing().type.toJust().value.state).toEqual(5);
+
+    });
+  });
+
+  describe('transitioning from the same type', ()=> {
+    it('is a no-oop', ()=> {
+      let just = Type.Just.create();
+      expect(just.type.toJust()).toBe(just);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6100,10 +6100,10 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8, micromatch@^3.1.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-microstates@0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/microstates/-/microstates-0.12.2.tgz#0885d9daee411e8a29a791f3ec35f74302496612"
-  integrity sha512-9JKec3oztJYeFajpbBc2ffpIMkYbe4ND2uIYwPXSNRapMAlQx09+5n4VIbACYcVQp2H7OEBxCfOzGRtRBz/0qw==
+microstates@0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/microstates/-/microstates-0.12.3.tgz#176def447c7625edf9b43c3cfc4bbcccd0e8be90"
+  integrity sha512-Rp69LbIrd1e+UjxqhUEt2MqTnTwfYavEwFnECVdJ2wNeEu/wZyLwvct9HJwsFRtvHB+80YCoqvTxdAYWobNwMQ==
   dependencies:
     funcadelic "^0.5.0"
     symbol-observable "^1.2.0"


### PR DESCRIPTION
One of the original conceptions of microstates was that it should be an effective way to use modelling your application state using state machines. One of the key insights was that there are strong analoguesbetween types and states, where each type corresponds to a distinct state. So for example, in a light switch state machine, you might have two types, each descending from a base state:

```javascript

class Switch {
  get isOn() { return false; }
  get isOff() { return false; }

  initialize(value) {
    if (value) {
      return create(On, true);
    } else {
      return create(Off, false);
    }
  }
}

class On extends Switch {
  get isOn() { return true; }

  flip() {
    return create(Off, false);
  }
}

class Off extends Switch {
  get isOff() { return true; }

  flip() {
    return create(On, true);
  }
}
```

This let's you start in one state, and gracefully transition to another.

```javascript
create(Switch, off).flip().flip().flip() //=> On {}
create(Switch, off).flip().flip().flip().isOn //=> true
```

This is really excellent to use, but expressing it can be fiddly to get right sometimes. It very much has the feeling of "stitching" together microstates to achive this nice thing, rather than something that microstates is expressly there to do.

What we really want is to be able to succinctly express a set of types and make sure that they adhere together in the following ways:

1. They all descend from the same superclass (On extends Switch, etc..)
2. They have the appropirate boolean state discriminator
   properties (isOn, isOff)
3. The initializers are properly wired together, and contain a
   recursive escape hatch to avoid infinite looping.

This change contains a prototype of a `Union` function that takes a descriptor and creates a Union type. The union types are based loosely off of Haskell union types e.g. `data Maybe a = Just a | Nothing`

Where the union type is represented as the superclass, and the constructors are represented by subclasses. Like Haskell union types, you the instance you get your hands on _must_ be one of the subclasses. I.e. I'll never be able to get a reference to a `Maybe`, instead it will always either be a `Just` or `Nothing`.

The `Union` function returns a class with an initializer that discriminates between which substate dependending on the value passed to create.

The `Switch` class above would be rewritten to take advantage of Unions like so:

```javascript
const Switch = Union({
  On: Switch => class extends Switch {
    flip() {
      return Switch.Off.create();
    }
  },
  Off: Switch => class extends Switch {
    flip() {
      return Switch.On.create();
    }
  }
});
```
Not only is this more concise, but critically, you don't have to remember to write your boolean discriminators and even more important, your custom initializers to make sure they coordinate together.

Every Union type has its members as properties of the main union type. So in our case, `Switch.On` and `Switch.Off`. To create a type directly, you can use the `create` method on each member.

```
let switch = Switch.Off.create(); Off {}
switch.isOff //=> true
switch.isOn //=> false
switch.type //=> 'Off'

let on = switch.flip(); //=> On {}
switch.isOff //=> false;
switch.isOn //=> true;
switch.type //=> 'On';
````

TODO
====

- Allow adding transitions and methods to the base class.
- Allow for tagged aliases: e.g. create(Color, 'red') instead of
  `create(Color, {type: 'Red'})`
- Allow custom initializers in union members.
- Shorthand for classes that don't have any special transitions

closes #7 