### PR TITLE
Allow to work with production Webpack build.

### DIFF
--- a/src/states/union.js
+++ b/src/states/union.js
@@ -1,6 +1,6 @@
 import { create, valueOf, Primitive } from 'microstates';
 
-export default function Union(members, Base = Object) {
+export default function Union(members, Base = class {}) {
   let types = Object.keys(members);
 
   let UnionType = class extends Base {
@@ -48,7 +48,7 @@ export default function Union(members, Base = Object) {
       value: type
     });
     Constructor.create = (value) => {
-      return create(UnionType, { type, value });
+      return create(Constructor, { type, value });
     };
     UnionType[type] = Constructor;
   });


### PR DESCRIPTION
Apparently, when a class explicitly extends `Object` like this:

```javascript
class Thing extends Object {

}
````

It's constructor is completely erased by a webpack production build and replaced by an invocation directly to `Object`

```javascript
new Thing() instanceof Thing //=> false
```

This feels like a pretty big bug in webpack, but it is easily fixed
enough by making the base class of a union default to an empty class
`class {}` instead of `Object`